### PR TITLE
Adds lucene search

### DIFF
--- a/couchdb.go
+++ b/couchdb.go
@@ -192,6 +192,30 @@ func (db *DB) Delete(id, rev string) (newrev string, err error) {
 	return responseRev(db.closedRequest("DELETE", path, nil))
 }
 
+// Search a document by search indexes
+func (db *DB) Search(ddoc, index string, searchParam Options) error {
+	searchParam["include_docs"] = "true"
+	if !strings.HasPrefix(ddoc, "_design/") {
+		return errors.New("couchdb.Search: design doc name must start with _design/")
+	}
+
+	searchQueryParam, err := encopts(searchParam, nil)
+	if err != nil {
+		return err
+	}
+
+	path := path(db.name, ddoc, "_search", index, searchQueryParam)
+
+	if len(path) <= 0 {
+		return nil
+	}
+	resp, err := db.request("GET", path, nil)
+	if err != nil {
+		return err
+	}
+	return readBody(resp, &Search{})
+}
+
 // Security represents database security objects.
 type Security struct {
 	Admins  Members `json:"admins"`

--- a/search.go
+++ b/search.go
@@ -1,0 +1,21 @@
+package couchdb
+
+type SearchResult struct {
+	Doc    interface{}       `json:"doc"`
+	Fields map[string]string `json:"fields"`
+	ID     string            `json:"id"`
+	Score  float64           `json:"score"`
+	Order  []float64         `json:"order"`
+}
+
+type Search struct {
+	ETag           string         `json:"etag,omitempty"`
+	FetchDuration  int64          `json:"fetch_duration,omitempty"`
+	Limit          int64          `json:"limit,omitempty"`
+	Query          string         `json:"q,omitempty"`
+	Rows           []SearchResult `json:"rows"`
+	SearchDuration int64          `json:"search_duration,omitempty"`
+	Skip           int64          `json:"skip,omitempty"`
+	TotalRows      int64          `json:"total_rows"`
+	Bookmark       int64          `json:"bookmark"`
+}


### PR DESCRIPTION
I would like to be able to support lucene searches with couchdb, I've tried this but i'm pretty sure many things are missing. Like the options to support to include_docs and to map it. 

Create 2 Search method? 
1. With include_docs and pass it the interface of the model to be able to map it.
2. Does not include_docs ever
